### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/ManeuverNodeSplitter/ManeuverNodeSplitter.version
+++ b/GameData/ManeuverNodeSplitter/ManeuverNodeSplitter.version
@@ -1,6 +1,6 @@
 {
   "NAME":"ManeuverNodeSplitter",
-  "URL":"https://github.com/linuxgurugamer/ManeuverNodeSplitter/raw/master/GameData/ManeuverNodeSplitter.version",
+  "URL":"https://github.com/linuxgurugamer/ManeuverNodeSplitter/raw/master/ManeuverNodeSplitter.version",
   "DOWNLOAD":"https://github.com/linuxgurugamer/ManeuverNodeSplitter/releases",
   "VERSION":{
     "MAJOR":1,

--- a/ManeuverNodeSplitter.version
+++ b/ManeuverNodeSplitter.version
@@ -1,6 +1,6 @@
 {
   "NAME":"ManeuverNodeSplitter",
-  "URL":"https://github.com/linuxgurugamer/ManeuverNodeSplitter/raw/master/GameData/ManeuverNodeSplitter.version",
+  "URL":"https://github.com/linuxgurugamer/ManeuverNodeSplitter/raw/master/ManeuverNodeSplitter.version",
   "DOWNLOAD":"https://github.com/linuxgurugamer/ManeuverNodeSplitter/releases",
   "VERSION":{
     "MAJOR":1,


### PR DESCRIPTION
The current URL property is a 404.
Now it's fixed.

Tagging @linuxgurugamer because not everyone has GitHub notifications enabled for pull requests.

@DasSkelett has created a nice GitHub Action that can validate these files for you before release:
- https://github.com/DasSkelett/AVC-VersionFileValidator